### PR TITLE
add compiled static endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 tide = "0.16"
 log = "0.4"
 async-std = "1.9"
+include_dir = "0.6.0"
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }

--- a/examples/compiled.rs
+++ b/examples/compiled.rs
@@ -1,0 +1,11 @@
+use tide_fs::prelude::*;
+
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
+    app.at("/")
+        .serve_compiled_dir(include_dir!("examples/static"), Some("index.html"));
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}

--- a/examples/static/index.html
+++ b/examples/static/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>hello world!</h1></body></html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,21 +37,30 @@
 
 use std::{io, path::Path};
 
-use prelude::{ServeDir, ServeFile};
+use prelude::{ServeDir, ServeDirCompiled, ServeFile};
 use tide::Route;
 
 pub mod serve_dir;
+pub mod serve_dir_compiled;
 pub mod serve_file;
+pub use include_dir::include_dir;
 
 pub mod prelude {
     pub use crate::serve_dir::ServeDir;
+    pub use crate::serve_dir_compiled::ServeDirCompiled;
     pub use crate::serve_file::ServeFile;
     pub use crate::TideFsExt;
+    pub use include_dir::include_dir;
 }
 
 pub trait TideFsExt {
     fn serve_file(&mut self, file: impl AsRef<Path>) -> io::Result<()>;
     fn serve_dir(&mut self, dir: impl AsRef<Path>) -> io::Result<()>;
+    fn serve_compiled_dir(
+        &mut self,
+        dir: include_dir::Dir<'static>,
+        index_file: Option<&'static str>,
+    );
 }
 
 impl<'a, State: Clone + Send + Sync + 'static> TideFsExt for Route<'a, State> {
@@ -63,5 +72,16 @@ impl<'a, State: Clone + Send + Sync + 'static> TideFsExt for Route<'a, State> {
     fn serve_dir(&mut self, dir: impl AsRef<Path>) -> io::Result<()> {
         self.at("*path").get(ServeDir::init(dir, "path")?);
         Ok(())
+    }
+
+    fn serve_compiled_dir(
+        &mut self,
+        dir: include_dir::Dir<'static>,
+        index_file: Option<&'static str>,
+    ) {
+        let serve_dir = ServeDirCompiled::new(dir, "path").with_index_file(index_file);
+        self.at("*path").get(serve_dir.clone());
+
+        self.at("").get(serve_dir);
     }
 }

--- a/src/serve_dir_compiled.rs
+++ b/src/serve_dir_compiled.rs
@@ -1,0 +1,78 @@
+use include_dir::{Dir, DirEntry, File};
+use std::ffi::OsStr;
+use tide::http::{content::ContentType, mime::Mime};
+use tide::{utils::async_trait, Endpoint, Request, Response, Result};
+
+#[derive(Clone)]
+pub struct ServeDirCompiled {
+    dir: Dir<'static>,
+    index_file: Option<&'static str>,
+    pattern: &'static str,
+}
+
+impl ServeDirCompiled {
+    pub fn new(dir: Dir<'static>, pattern: &'static str) -> Self {
+        Self {
+            pattern,
+            dir,
+            index_file: None,
+        }
+    }
+
+    pub fn with_index_file(mut self, file: Option<&'static str>) -> Self {
+        self.index_file = file;
+        self
+    }
+
+    fn serve_file(&self, file: File) -> Response {
+        let mut res = Response::new(200);
+        if let Some(mime) = file
+            .path()
+            .extension()
+            .and_then(OsStr::to_str)
+            .and_then(Mime::from_extension)
+        {
+            ContentType::new(mime).apply(&mut res);
+        }
+        res.set_body(file.contents());
+        res
+    }
+
+    fn get_item(&self, path: &str) -> Option<DirEntry> {
+        if path == "" {
+            Some(DirEntry::Dir(self.dir))
+        } else if let Some(dir) = self.dir.get_dir(path) {
+            Some(DirEntry::Dir(dir))
+        } else if let Some(file) = self.dir.get_file(path) {
+            Some(DirEntry::File(file))
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl<State: Clone + Send + Sync + 'static> Endpoint<State> for ServeDirCompiled {
+    async fn call(&self, req: Request<State>) -> Result {
+        let entry = self.get_item(
+            req.param(self.pattern)
+                .unwrap_or("")
+                .trim_start_matches('/'),
+        );
+
+        let response = match (entry, self.index_file) {
+            (None, _) => None,
+            (Some(DirEntry::File(file)), _) => Some(self.serve_file(file)),
+            (Some(DirEntry::Dir(_)), None) => None,
+            (Some(DirEntry::Dir(dir)), Some(index_file)) => {
+                if let Some(file) = dir.get_file(index_file) {
+                    Some(self.serve_file(file))
+                } else {
+                    None
+                }
+            }
+        };
+
+        Ok(response.unwrap_or_else(|| Response::new(404)))
+    }
+}


### PR DESCRIPTION
there are a few design decisions here i wasn't sure about:

1. i wasn't sure how to configure the endpoint so had to pass in an optional index file instead of using a fluent interface. i think this represents a larger issue with tide's router that is beyond the scope of this crate
2. worked around a bug in tide's router in order to serve both on "*" and "/"
